### PR TITLE
Introduce storageGroup on Output

### DIFF
--- a/Puree.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Puree.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Puree/BufferedOutput.swift
+++ b/Sources/Puree/BufferedOutput.swift
@@ -87,6 +87,11 @@ open class BufferedOutput: Output {
         completion(false)
     }
 
+    open var storageGroup: String {
+        let typeName = String(describing: type(of: self))
+        return "\(tagPattern.pattern)_\(typeName)"
+    }
+
     private func setUpTimer() {
         self.timer?.invalidate()
 

--- a/Sources/Puree/BufferedOutput.swift
+++ b/Sources/Puree/BufferedOutput.swift
@@ -76,7 +76,7 @@ open class BufferedOutput: Output {
     public func emit(log: LogEntry) {
         buffer.insert(log)
 
-        logStore.add(log, for: tagPattern.pattern, completion: nil)
+        logStore.add(log, for: storageGroup, completion: nil)
 
         if buffer.count >= logLimit {
             flush()
@@ -112,7 +112,7 @@ open class BufferedOutput: Output {
     private func reloadLogStore() {
         buffer.removeAll()
 
-        logStore.retrieveLogs(of: tagPattern.pattern) { logs in
+        logStore.retrieveLogs(of: storageGroup) { logs in
             buffer = buffer.union(logs)
         }
     }
@@ -139,7 +139,7 @@ open class BufferedOutput: Output {
     private func callWriteChunk(_ chunk: Chunk) {
         write(chunk) { success in
             if success {
-                self.logStore.remove(chunk.logs, from: self.tagPattern.pattern, completion: nil)
+                self.logStore.remove(chunk.logs, from: self.storageGroup, completion: nil)
                 return
             }
 

--- a/Sources/Puree/LogStore/FileLogStore.swift
+++ b/Sources/Puree/LogStore/FileLogStore.swift
@@ -58,8 +58,8 @@ public class FileLogStore: LogStore {
 
     private func fileURL(for group: String) -> URL {
         let fileName = "\(FileLogStore.baseFileName)_\(group)"
-        // Tag patterns usually contain '*'. However we can't to use special characters in filenames.
-        // So filenames should be encoded to base16.
+        // Tag patterns usually contain '*'. However we don't want to use special characters in filenames
+        // so encode file names to Base16
         return baseDirectoryURL.appendingPathComponent(encodeToBase16(fileName))
     }
     private var fileManager: FileManagerProtocol = SystemFileManager()

--- a/Sources/Puree/LogStore/FileLogStore.swift
+++ b/Sources/Puree/LogStore/FileLogStore.swift
@@ -49,7 +49,6 @@ struct SystemFileManager: FileManagerProtocol {
 }
 
 public class FileLogStore: LogStore {
-    private static let baseFileName = "com.cookpad.Puree.FileLogStore"
     private static let directoryName = "PureeLogs"
     private var bundle: Bundle = Bundle.main
     private var baseDirectoryURL: URL!
@@ -57,10 +56,9 @@ public class FileLogStore: LogStore {
     public static let `default` = FileLogStore()
 
     private func fileURL(for group: String) -> URL {
-        let fileName = "\(FileLogStore.baseFileName)_\(group)"
         // Tag patterns usually contain '*'. However we don't want to use special characters in filenames
         // so encode file names to Base16
-        return baseDirectoryURL.appendingPathComponent(encodeToBase16(fileName))
+        return baseDirectoryURL.appendingPathComponent(encodeToBase16(group))
     }
     private var fileManager: FileManagerProtocol = SystemFileManager()
 

--- a/Sources/Puree/LogStore/FileLogStore.swift
+++ b/Sources/Puree/LogStore/FileLogStore.swift
@@ -58,7 +58,7 @@ public class FileLogStore: LogStore {
 
     private func fileURL(for group: String) -> URL {
         let fileName = "\(FileLogStore.baseFileName)_\(group)"
-        return baseDirectoryURL.appendingPathComponent(fileName)
+        return baseDirectoryURL.appendingPathComponent(encodeToBase16(fileName))
     }
     private var fileManager: FileManagerProtocol = SystemFileManager()
 
@@ -109,5 +109,9 @@ public class FileLogStore: LogStore {
     public func flush() {
         try? fileManager.removeDirectory(at: baseDirectoryURL)
         try? createCachesDirectory()
+    }
+
+    private func encodeToBase16(_ string: String) -> String {
+        return string.data(using: .utf8)!.map { String(format: "%02hhx", $0) }.joined()
     }
 }

--- a/Sources/Puree/LogStore/FileLogStore.swift
+++ b/Sources/Puree/LogStore/FileLogStore.swift
@@ -58,6 +58,8 @@ public class FileLogStore: LogStore {
 
     private func fileURL(for group: String) -> URL {
         let fileName = "\(FileLogStore.baseFileName)_\(group)"
+        // Tag patterns usually contain '*'. However we can't to use special characters in filenames.
+        // So filenames should be encoded to base16.
         return baseDirectoryURL.appendingPathComponent(encodeToBase16(fileName))
     }
     private var fileManager: FileManagerProtocol = SystemFileManager()

--- a/Sources/Puree/LogStore/FileLogStore.swift
+++ b/Sources/Puree/LogStore/FileLogStore.swift
@@ -56,8 +56,8 @@ public class FileLogStore: LogStore {
 
     public static let `default` = FileLogStore()
 
-    func fileURL(for outputTagPattern: String) -> URL {
-        let fileName = "\(FileLogStore.baseFileName)_\(outputTagPattern)"
+    private func fileURL(for group: String) -> URL {
+        let fileName = "\(FileLogStore.baseFileName)_\(group)"
         return baseDirectoryURL.appendingPathComponent(fileName)
     }
     private var fileManager: FileManagerProtocol = SystemFileManager()

--- a/Sources/Puree/Output.swift
+++ b/Sources/Puree/Output.swift
@@ -22,6 +22,7 @@ public struct OutputSetting: OutputSettingProtocol {
 
 public protocol Output {
     var tagPattern: TagPattern { get }
+    var storageGroup: String { get }
 
     func start()
     func resume()
@@ -39,5 +40,10 @@ public extension Output {
     }
 
     func suspend() {
+    }
+
+    var storageGroup: String {
+        let typeName = String(describing: type(of: self))
+        return "\(tagPattern.pattern)_\(typeName)"
     }
 }

--- a/Sources/Puree/Output.swift
+++ b/Sources/Puree/Output.swift
@@ -22,7 +22,6 @@ public struct OutputSetting: OutputSettingProtocol {
 
 public protocol Output {
     var tagPattern: TagPattern { get }
-    var storageGroup: String { get }
 
     func start()
     func resume()
@@ -40,10 +39,5 @@ public extension Output {
     }
 
     func suspend() {
-    }
-
-    var storageGroup: String {
-        let typeName = String(describing: type(of: self))
-        return "\(tagPattern.pattern)_\(typeName)"
     }
 }

--- a/Sources/Puree/TagPattern.swift
+++ b/Sources/Puree/TagPattern.swift
@@ -4,12 +4,16 @@ private let separator: Character = "."
 private let allWildcard = "**"
 private let wildcard = "*"
 
-public struct TagPattern {
+public struct TagPattern: CustomStringConvertible {
     struct Match {
         let captured: String?
     }
 
     public let pattern: String
+
+    public var description: String {
+        return pattern
+    }
 
     public init?(string patternString: String) {
         if TagPattern.isValidPattern(patternString) {

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,3 +1,5 @@
 disabled_rules:
   - force_try
   - force_cast
+  - nesting
+  - identifier_name

--- a/Tests/PureeTests/BufferedOutputTests.swift
+++ b/Tests/PureeTests/BufferedOutputTests.swift
@@ -35,7 +35,7 @@ class BufferedOutputTests: XCTestCase {
 
     func testBufferedOutput() {
         output.configuration.logEntryCountLimit = 1
-        XCTAssertEqual(logStore.logs(for: "pv").count, 0)
+        XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 0)
         XCTAssertEqual(output.calledWriteCount, 0)
         output.emit(log: makeLog())
         XCTAssertEqual(output.calledWriteCount, 1)
@@ -46,21 +46,21 @@ class BufferedOutputTests: XCTestCase {
         output.configuration.flushInterval = 1
 
         let storedLogs: Set<LogEntry> = Set((0..<10).map { _ in LogEntry(tag: "pv", date: Date()) })
-        logStore.add(storedLogs, for: "pv", completion: nil)
+        logStore.add(storedLogs, for: "pv_TestingBufferedOutput", completion: nil)
 
-        XCTAssertEqual(logStore.logs(for: "pv").count, 10)
+        XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 10)
         XCTAssertEqual(output.calledWriteCount, 0)
 
         output.resume()
 
-        XCTAssertEqual(logStore.logs(for: "pv").count, 0)
+        XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 0)
         XCTAssertEqual(output.calledWriteCount, 1)
     }
 
     func testBufferedOutputFlushedByInterval() {
         output.configuration.logEntryCountLimit = 10
         output.configuration.flushInterval = 1
-        XCTAssertEqual(logStore.logs(for: "pv").count, 0)
+        XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 0)
         XCTAssertEqual(output.calledWriteCount, 0)
         output.emit(log: makeLog())
         XCTAssertEqual(output.calledWriteCount, 0)
@@ -75,7 +75,7 @@ class BufferedOutputTests: XCTestCase {
     func testBufferedOutputNotFlushed() {
         output.configuration.logEntryCountLimit = 10
         output.configuration.flushInterval = 10
-        XCTAssertEqual(logStore.logs(for: "pv").count, 0)
+        XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 0)
         XCTAssertEqual(output.calledWriteCount, 0)
         output.emit(log: makeLog())
         XCTAssertEqual(output.calledWriteCount, 0)
@@ -88,11 +88,11 @@ class BufferedOutputTests: XCTestCase {
 
     func testHittingLogLimit() {
         output.configuration.logEntryCountLimit = 10
-        XCTAssertEqual(logStore.logs(for: "pv").count, 0)
+        XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 0)
         XCTAssertEqual(output.calledWriteCount, 0)
         for i in 1..<10 {
             output.emit(log: makeLog())
-            XCTAssertEqual(logStore.logs(for: "pv").count, i)
+            XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, i)
         }
         XCTAssertEqual(output.calledWriteCount, 0)
 
@@ -112,7 +112,7 @@ class BufferedOutputTests: XCTestCase {
 
         var expectation = self.expectation(description: "retry writeChunk")
         XCTAssertEqual(output.calledWriteCount, 1)
-        XCTAssertEqual(logStore.logs(for: "pv").count, 10)
+        XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 10)
         output.writeCallback = {
             expectation.fulfill()
         }
@@ -120,7 +120,7 @@ class BufferedOutputTests: XCTestCase {
 
         expectation = self.expectation(description: "retry writeChunk")
         XCTAssertEqual(output.calledWriteCount, 2)
-        XCTAssertEqual(logStore.logs(for: "pv").count, 10)
+        XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 10)
         output.writeCallback = {
             expectation.fulfill()
         }
@@ -128,7 +128,7 @@ class BufferedOutputTests: XCTestCase {
 
         expectation = self.expectation(description: "retry writeChunk")
         XCTAssertEqual(output.calledWriteCount, 3)
-        XCTAssertEqual(logStore.logs(for: "pv").count, 10)
+        XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 10)
         output.writeCallback = {
             expectation.fulfill()
         }


### PR DESCRIPTION
## Motivation and Context

If you sent logs to multiple buffered outputs. stored logs are shared between them.
This behavior causes some problems.
In Puree-ObjC, log stores are separated by class names of buffered outputs.

https://github.com/cookpad/puree-ios/blob/master/Pod/Classes/PURLogStore.m#L102

## Description

I introduced `storageGroup` property on `Output`. destination file names are decided from this value.

This change breaks compatibility. This upgrade will miss unsent logs.
If you want to use stored logs of earlier versions, you can override `storageGroup`.

filenames are encoded in base16 because to treat invalid characters.