### PR TITLE
Logger.resume works asynchronous

### DIFF
--- a/Sources/Puree/Logger.swift
+++ b/Sources/Puree/Logger.swift
@@ -86,8 +86,8 @@ public final class Logger {
     }
 
     public func resume() {
-        dispatchQueue.sync {
-            outputs.forEach { $0.resume() }
+        dispatchQueue.async {
+            self.outputs.forEach { $0.resume() }
         }
     }
 


### PR DESCRIPTION
`Logger.resume` should work asynchronously as` Logger.start`.