### PR TITLE
BufferedOutput timer does not schedule when setup from a background queue

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,8 @@
-included: 
+included:
   - Sources
   - Tests/PureeTests
 disabled_rules:
   - line_length
+  - file_length
 trailing_comma:
   mandatory_comma: true

--- a/Puree.podspec
+++ b/Puree.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Puree"
-  s.version      = "4.0.0"
+  s.version      = "4.0.1"
   s.summary      = "Awesome log aggregator"
   s.homepage     = "https://github.com/cookpad/Puree-Swift"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -114,7 +114,7 @@ open class BufferedOutput: Output {
                           selector: #selector(tick(_:)),
                           userInfo: nil,
                           repeats: true)
-        RunLoop.current.add(timer, forMode: .common)
+        RunLoop.main.add(timer, forMode: .common)
         self.timer = timer
     }
 

--- a/Tests/PureeTests/Output/BufferedOutputTests.swift
+++ b/Tests/PureeTests/Output/BufferedOutputTests.swift
@@ -381,30 +381,24 @@ class BufferedOutputAsyncTests: XCTestCase {
 
 class BufferedOutputDispatchQueueTests: XCTestCase {
 
-    func testFlushInterval() {
+    func testFlushIntervalOnDifferentDispatchQueue() {
         let exp = expectation(description: #function)
-
-        // Run the test on a background queue
         let dispatchQueue = DispatchQueue(label: "com.cookpad.Puree.Logger", qos: .background)
-        dispatchQueue.async {
 
-            // Setup the output
+        dispatchQueue.async {
             let logStore = InMemoryLogStore()
             let output = TestingBufferedOutput(logStore: logStore, tagPattern: TagPattern(string: "pv")!, options: nil)
             output.configuration = BufferedOutput.Configuration(logEntryCountLimit: 5, flushInterval: 0, retryLimit: 3)
             output.start()
 
-            // Add a log to the buffer. The configuration should cause it to be flushed on the next timer event
             output.emit(log: makeLog())
 
-            // Verify that the buffer was written
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
                 XCTAssertEqual(output.calledWriteCount, 1)
                 exp.fulfill()
             }
         }
 
-        // The internal timer should perform a flush within 1 second.
         waitForExpectations(timeout: 10.0)
     }
 }

--- a/Tests/PureeTests/Output/BufferedOutputTests.swift
+++ b/Tests/PureeTests/Output/BufferedOutputTests.swift
@@ -378,3 +378,33 @@ class BufferedOutputAsyncTests: XCTestCase {
         logStore.flush()
     }
 }
+
+class BufferedOutputDispatchQueueTests: XCTestCase {
+
+    func testFlushInterval() {
+        let exp = expectation(description: #function)
+
+        // Run the test on a background queue
+        let dispatchQueue = DispatchQueue(label: "com.cookpad.Puree.Logger", qos: .background)
+        dispatchQueue.async {
+
+            // Setup the output
+            let logStore = InMemoryLogStore()
+            let output = TestingBufferedOutput(logStore: logStore, tagPattern: TagPattern(string: "pv")!, options: nil)
+            output.configuration = BufferedOutput.Configuration(logEntryCountLimit: 5, flushInterval: 0, retryLimit: 3)
+            output.start()
+
+            // Add a log to the buffer. The configuration should cause it to be flushed on the next timer event
+            output.emit(log: makeLog())
+
+            // Verify that the buffer was written
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                XCTAssertEqual(output.calledWriteCount, 1)
+                exp.fulfill()
+            }
+        }
+
+        // The internal timer should perform a flush within 1 second.
+        waitForExpectations(timeout: 10.0)
+    }
+}


### PR DESCRIPTION
As of #16, the `Logger` starts all outputs on a background queue. As a result of this, the `BufferedOutput.setUpTimer()` function is now being executed on the background queue set by the logger and not the main queue as it was in 3.3.0.  

This PR currently introduces a unit test that replicates the issue. 

It appears that this can be simply fixed by scheduling the timer on `RunLoop.main` instead of `RunLoop.current` however I'm not familiar with Puree enough to know if this change will be safe or not so I have the following questions:

1) Is there a better way to write this unit test? I worry that it might be unreliable.
2) Does scheduling the `Timer` to run on `RunLoop.main` defeat the object of #16? I _think_ that it is ok to do this but just want to be sure that the results (`BufferedOutput.tick(_:)` will run on the main thread) are acceptable. 

I can commit a fix once it's been decided how we should proceed