### PR TITLE
Crash when deallocating Logger

### DIFF
--- a/Puree.podspec
+++ b/Puree.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Puree"
-  s.version      = "4.0.1"
+  s.version      = "4.0.2"
   s.summary      = "Awesome log aggregator"
   s.homepage     = "https://github.com/cookpad/Puree-Swift"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/Sources/Puree/Logger.swift
+++ b/Sources/Puree/Logger.swift
@@ -98,8 +98,4 @@ public final class Logger {
             outputs.removeAll()
         }
     }
-
-    deinit {
-        shutdown()
-    }
 }


### PR DESCRIPTION
Apparently (after Googling), Swift classes are deallocated from the thread that they were last retained on meaning that you cannot guarantee the thread that `deinit` is executed from. 

In the case of `Logger`, if you last called a function where `self` was captured internally in it's internal dispatch queue (i.e `Logger.resume()`) then the `deinit` function is executed from the internal dispatch queue. 

In the current implementation, `deinit` calls `Logger.shutdown()` that then attempts to execute `dispatchQueue.sync { ... }` while already on the internal dispatch queue resulting in the framework crashing with `EXC_BAD_INSTRUCTION`

<img width="1097" alt="screenshot 2019-01-14 at 16 33 56" src="https://user-images.githubusercontent.com/482871/51126103-3346b900-181a-11e9-893b-4ab37d999fac.png">

You can reproduce the scenario with the following test case: 

```swift
func testLoggerDeallocation() {

    let configuration = Logger.Configuration(logStore: logStore,
                                             dateProvider: DefaultDateProvider(),
                                             filterSettings: [FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv")!)],
                                             outputSettings: [OutputSetting(PVLogOutput.self, tagPattern: TagPattern(string: "pv")!)])
    var logger: Logger? = try? Logger(configuration: configuration)
    XCTAssertNotNil(logger)

    logger?.postLog(["foo":"bar"], tag: "pv")
    logger?.suspend()

    weak var weakLogger: Logger? = logger
    logger?.resume()
    logger = nil

    let exp = expectation(description: #function)
    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
        XCTAssertNil(weakLogger)
        exp.fulfill()
    }
    waitForExpectations(timeout: 10.0, handler: nil)
}
```

This change removes the `deinit` implementation as it seems unnecessary although I'm not sure if we actually need to be able to suspend the outputs or not still? 

If we still need to suspend the outputs then maybe I should add it back but call `dispatchQueue.async` instead of `.sync`?   