### PR TITLE
Simplify Output initializer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import Puree
 struct PVLogFilter: Filter {
     let tagPattern: TagPattern
 
-    init(tagPattern: TagPattern, options: FilterOptions?) {
+    init(tagPattern: TagPattern) {
         self.tagPattern = tagPattern
     }
 
@@ -86,7 +86,7 @@ The following `ConsoleOutput` will output logs to the standard output.
 class ConsoleOutput: Output {
     let tagPattern: TagPattern
 
-    required init(logStore: LogStore, tagPattern: TagPattern, options: OutputOptions?) {
+    required init(logStore: LogStore, tagPattern: TagPattern) {
         self.tagPattern = tagPattern
     }
 
@@ -128,16 +128,20 @@ After implementing filters and outputs, you can configure the routing with `Logg
 import Puree
 
 let configuration = Logger.Configuration(filterSettings: [
-                                             FilterSetting(PVLogFilter.self,
-                                                           tagPattern: TagPattern(string: "pv.**")!),
+                                             FilterSetting{
+                                                 PVLogFilter(tagPattern: TagPattern(string: "pv.**")!)
+                                             }
                                          ],
                                          outputSettings: [
-                                             OutputSetting(ConsoleOutput.self,
-                                                           tagPattern: TagPattern(string: "activity.**")!),
-                                             OutputSetting(ConsoleOutput.self,
-                                                           tagPattern: TagPattern(string: "pv.**")!),
-                                             OutputSetting(LogServerOutput.self,
-                                                           tagPattern: TagPattern(string: "pv.**")!),
+                                             OutputSetting {
+                                                 PVLogOutput(logStore: $0, tagPattern: TagPattern(string: "activity.**")!)
+                                             },
+                                             OutputSetting {
+                                                 ConsoleOutput(logStore: $0, tagPattern: TagPattern(string: "pv.**")!)
+                                             },
+                                             OutputSetting {
+                                                 LogServerOutput(logStore: $0, tagPattern: TagPattern(string: "pv.**")!)
+                                             },
                                          ])
 let logger = try! Logger(configuration: configuration)
 logger.postLog(["page_name": "top", "user_id": 100], tag: "pv.top")

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ After implementing filters and outputs, you can configure the routing with `Logg
 import Puree
 
 let configuration = Logger.Configuration(filterSettings: [
-                                             FilterSetting{
+                                             FilterSetting {
                                                  PVLogFilter(tagPattern: TagPattern(string: "pv.**")!)
                                              }
                                          ],

--- a/Sources/Puree/Filter.swift
+++ b/Sources/Puree/Filter.swift
@@ -1,15 +1,18 @@
 import Foundation
 
-public typealias FilterOptions = [String: Any]
-
 public protocol FilterSettingProtocol {
     func makeFilter() throws -> Filter
 }
 
 public struct FilterSetting: FilterSettingProtocol {
-    public init<F: Filter>(_ filter: F.Type, tagPattern: TagPattern, options: FilterOptions? = nil) {
+
+    public init(makeFiilter: @escaping () -> Filter) {
+        self.makeFilterBlock = makeFiilter
+    }
+
+    public init<F: InstantiatableFilter>(_ filter: F.Type, tagPattern: TagPattern) {
         makeFilterBlock = {
-            return F(tagPattern: tagPattern, options: options)
+            return F(tagPattern: tagPattern)
         }
     }
 
@@ -24,6 +27,8 @@ public protocol Filter {
     var tagPattern: TagPattern { get }
 
     func convertToLogs(_ payload: [String: Any]?, tag: String, captured: String?, logger: Logger) -> Set<LogEntry>
+}
 
-    init(tagPattern: TagPattern, options: FilterOptions?)
+public protocol InstantiatableFilter: Filter {
+    init(tagPattern: TagPattern)
 }

--- a/Sources/Puree/Filter.swift
+++ b/Sources/Puree/Filter.swift
@@ -10,14 +10,14 @@ public struct FilterSetting: FilterSettingProtocol {
         self.makeFilterBlock = makeFiilter
     }
 
-    public init<F: InstantiatableFilter>(_ filter: F.Type, tagPattern: TagPattern) {
+    public init<F: InstantiatableFilter>(_ filter: F.Type, tagPattern: TagPattern, options: FilterOptions? = nil) {
         makeFilterBlock = {
-            return F(tagPattern: tagPattern)
+            return F(tagPattern: tagPattern, options: options)
         }
     }
 
     @available(*, unavailable, message: "Please conform InstantiatableFilter or use init with closure.")
-    public init<F: Filter>(_ filter: F.Type, tagPattern: TagPattern, options: [String: Any]? = nil) {
+    public init<F: Filter>(_ filter: F.Type, tagPattern: TagPattern, options: FilterOptions? = nil) {
         fatalError("unavailable")
     }
 
@@ -34,6 +34,8 @@ public protocol Filter {
     func convertToLogs(_ payload: [String: Any]?, tag: String, captured: String?, logger: Logger) -> Set<LogEntry>
 }
 
+public typealias FilterOptions = [String: Any]
+
 public protocol InstantiatableFilter: Filter {
-    init(tagPattern: TagPattern)
+    init(tagPattern: TagPattern, options: FilterOptions?)
 }

--- a/Sources/Puree/Filter.swift
+++ b/Sources/Puree/Filter.swift
@@ -16,6 +16,11 @@ public struct FilterSetting: FilterSettingProtocol {
         }
     }
 
+    @available(*, unavailable, message: "Please conform InstantiatableFilter or use init with closure.")
+    public init<F: Filter>(_ filter: F.Type, tagPattern: TagPattern, options: [String: Any]? = nil) {
+        fatalError("unavailable")
+    }
+
     public func makeFilter() throws -> Filter {
         return makeFilterBlock()
     }

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -7,7 +7,6 @@ open class BufferedOutput: Output {
     public init(logStore: LogStore, tagPattern: TagPattern) {
         self.logStore = logStore
         self.tagPattern = tagPattern
-        self.options = options
     }
 
     public struct Chunk: Hashable {
@@ -39,7 +38,6 @@ open class BufferedOutput: Output {
     }
 
     public let tagPattern: TagPattern
-    public let options: OutputOptions?
     private let logStore: LogStore
     public var configuration: Configuration = .default
 

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-open class BufferedOutput: InstantiatableOutput {
+open class BufferedOutput: Output {
     private let dateProvider: DateProvider = DefaultDateProvider()
     internal let readWriteQueue = DispatchQueue(label: "com.cookpad.Puree.Logger.BufferedOutput", qos: .background)
 
-    public required init(logStore: LogStore, tagPattern: TagPattern, options: OutputOptions?) {
+    public init(logStore: LogStore, tagPattern: TagPattern) {
         self.logStore = logStore
         self.tagPattern = tagPattern
         self.options = options

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-open class BufferedOutput: Output {
+open class BufferedOutput: InstantiatableOutput {
     private let dateProvider: DateProvider = DefaultDateProvider()
     internal let readWriteQueue = DispatchQueue(label: "com.cookpad.Puree.Logger.BufferedOutput", qos: .background)
 

--- a/Sources/Puree/Output/Output.swift
+++ b/Sources/Puree/Output/Output.swift
@@ -1,15 +1,18 @@
 import Foundation
 
-public typealias OutputOptions = [String: Any]
-
 public protocol OutputSettingProtocol {
     func makeOutput(_ logStore: LogStore) throws -> Output
 }
 
 public struct OutputSetting: OutputSettingProtocol {
-    public init<O: InstantiatableOutput>(_ output: O.Type, tagPattern: TagPattern, options: OutputOptions? = nil) {
+
+    public init(makeOutput: @escaping (_ logStore: LogStore) -> Output) {
+        self.makeOutputBlock = makeOutput
+    }
+
+    public init<O: InstantiatableOutput>(_ output: O.Type, tagPattern: TagPattern) {
         makeOutputBlock = { logStore in
-            return O(logStore: logStore, tagPattern: tagPattern, options: options)
+            return O(logStore: logStore, tagPattern: tagPattern)
         }
     }
 
@@ -31,7 +34,7 @@ public protocol Output {
 }
 
 public protocol InstantiatableOutput: Output {
-    init(logStore: LogStore, tagPattern: TagPattern, options: OutputOptions?)
+    init(logStore: LogStore, tagPattern: TagPattern)
 }
 
 public extension Output {

--- a/Sources/Puree/Output/Output.swift
+++ b/Sources/Puree/Output/Output.swift
@@ -10,14 +10,14 @@ public struct OutputSetting: OutputSettingProtocol {
         self.makeOutputBlock = makeOutput
     }
 
-    public init<O: InstantiatableOutput>(_ output: O.Type, tagPattern: TagPattern) {
+    public init<O: InstantiatableOutput>(_ output: O.Type, tagPattern: TagPattern, options: OutputOptions? = nil) {
         makeOutputBlock = { logStore in
-            return O(logStore: logStore, tagPattern: tagPattern)
+            return O(logStore: logStore, tagPattern: tagPattern, options: options)
         }
     }
 
     @available(*, unavailable, message: "Please conform InstantiatableOutput or use init with closure.")
-    public init<O: Output>(_ output: O.Type, tagPattern: TagPattern, options: [String: Any]? = nil) {
+    public init<O: Output>(_ output: O.Type, tagPattern: TagPattern, options: OutputOptions? = nil) {
         fatalError("unavailable")
     }
 
@@ -38,8 +38,10 @@ public protocol Output {
 
 }
 
+public typealias OutputOptions = [String: Any]
+
 public protocol InstantiatableOutput: Output {
-    init(logStore: LogStore, tagPattern: TagPattern)
+    init(logStore: LogStore, tagPattern: TagPattern, options: OutputOptions?)
 }
 
 public extension Output {

--- a/Sources/Puree/Output/Output.swift
+++ b/Sources/Puree/Output/Output.swift
@@ -16,6 +16,11 @@ public struct OutputSetting: OutputSettingProtocol {
         }
     }
 
+    @available(*, unavailable, message: "Please conform InstantiatableOutput or use init with closure.")
+    public init<O: Output>(_ output: O.Type, tagPattern: TagPattern, options: [String: Any]? = nil) {
+        fatalError("unavailable")
+    }
+
     public func makeOutput(_ logStore: LogStore) -> Output {
         return makeOutputBlock(logStore)
     }

--- a/Sources/Puree/Output/Output.swift
+++ b/Sources/Puree/Output/Output.swift
@@ -7,7 +7,7 @@ public protocol OutputSettingProtocol {
 }
 
 public struct OutputSetting: OutputSettingProtocol {
-    public init<O: Output>(_ output: O.Type, tagPattern: TagPattern, options: OutputOptions? = nil) {
+    public init<O: InstantiatableOutput>(_ output: O.Type, tagPattern: TagPattern, options: OutputOptions? = nil) {
         makeOutputBlock = { logStore in
             return O(logStore: logStore, tagPattern: tagPattern, options: options)
         }
@@ -28,6 +28,9 @@ public protocol Output {
     func suspend()
     func emit(log: LogEntry)
 
+}
+
+public protocol InstantiatableOutput: Output {
     init(logStore: LogStore, tagPattern: TagPattern, options: OutputOptions?)
 }
 

--- a/Tests/PureeTests/LoggerTests.swift
+++ b/Tests/PureeTests/LoggerTests.swift
@@ -5,7 +5,7 @@ import Puree
 let buffer = TestingBuffer()
 
 struct PVLogFilter: Filter {
-    init(tagPattern: TagPattern, options: FilterOptions?) {
+    init(tagPattern: TagPattern, options: [String: Any]? = nil) {
         self.tagPattern = tagPattern
     }
 
@@ -41,7 +41,9 @@ class LoggerTests: XCTestCase {
         let configuration = Logger.Configuration(logStore: logStore,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
-                                                    FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv")!),
+                                                    FilterSetting {
+                                                        PVLogFilter(tagPattern: TagPattern(string: "pv")!)
+                                                    },
             ],
                                                  outputSettings: [
                                                     OutputSetting {
@@ -66,9 +68,15 @@ class LoggerTests: XCTestCase {
         let configuration = Logger.Configuration(logStore: logStore,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
-                                                    FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv")!),
-                                                    FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv2")!),
-                                                    FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv.*")!),
+                                                    FilterSetting {
+                                                        PVLogFilter(tagPattern: TagPattern(string: "pv")!)
+                                                    },
+                                                    FilterSetting {
+                                                        PVLogFilter(tagPattern: TagPattern(string: "pv2")!)
+                                                    },
+                                                    FilterSetting{
+                                                        PVLogFilter(tagPattern: TagPattern(string: "pv.*")!)
+                                                    },
             ],
                                                  outputSettings: [
                                                     OutputSetting {
@@ -120,9 +128,13 @@ class LoggerTests: XCTestCase {
         let configuration = Logger.Configuration(logStore: logStore,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
-                                                    FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv")!),
+                                                    FilterSetting{
+                                                        PVLogFilter(tagPattern: TagPattern(string: "pv")!)
+                                                    },
                                                     CustomFilterSetting(tableName: "pv_log"),
-                                                    FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv.*")!),
+                                                    FilterSetting{
+                                                        PVLogFilter(tagPattern: TagPattern(string: "pv.*")!)
+                                                    },
             ],
                                                  outputSettings: [
                                                     OutputSetting {
@@ -148,8 +160,10 @@ class LoggerTests: XCTestCase {
         let configuration = Logger.Configuration(logStore: logStore,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
-                                                    FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv")!),
-                                                    ],
+                                                    FilterSetting {
+                                                        PVLogFilter(tagPattern: TagPattern(string: "pv")!)
+                                                    },
+            ],
                                                  outputSettings: [
                                                     OutputSetting {
                                                         PVLogOutput(logStore: $0, tagPattern: TagPattern(string: "pv")!)

--- a/Tests/PureeTests/LoggerTests.swift
+++ b/Tests/PureeTests/LoggerTests.swift
@@ -22,7 +22,7 @@ struct PVLogFilter: Filter {
     }
 }
 
-struct PVLogOutput: Output {
+struct PVLogOutput: InstantiatableOutput {
     let tagPattern: TagPattern
 
     init(logStore: LogStore, tagPattern: TagPattern, options: OutputOptions?) {

--- a/Tests/PureeTests/LoggerTests.swift
+++ b/Tests/PureeTests/LoggerTests.swift
@@ -74,7 +74,7 @@ class LoggerTests: XCTestCase {
                                                     FilterSetting {
                                                         PVLogFilter(tagPattern: TagPattern(string: "pv2")!)
                                                     },
-                                                    FilterSetting{
+                                                    FilterSetting {
                                                         PVLogFilter(tagPattern: TagPattern(string: "pv.*")!)
                                                     },
             ],
@@ -128,11 +128,11 @@ class LoggerTests: XCTestCase {
         let configuration = Logger.Configuration(logStore: logStore,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
-                                                    FilterSetting{
+                                                    FilterSetting {
                                                         PVLogFilter(tagPattern: TagPattern(string: "pv")!)
                                                     },
                                                     CustomFilterSetting(tableName: "pv_log"),
-                                                    FilterSetting{
+                                                    FilterSetting {
                                                         PVLogFilter(tagPattern: TagPattern(string: "pv.*")!)
                                                     },
             ],

--- a/Tests/PureeTests/LoggerTests.swift
+++ b/Tests/PureeTests/LoggerTests.swift
@@ -22,10 +22,10 @@ struct PVLogFilter: Filter {
     }
 }
 
-struct PVLogOutput: InstantiatableOutput {
+struct PVLogOutput: Output {
     let tagPattern: TagPattern
 
-    init(logStore: LogStore, tagPattern: TagPattern, options: OutputOptions?) {
+    init(logStore: LogStore, tagPattern: TagPattern, options: [String: Any]? = nil) {
         self.tagPattern = tagPattern
     }
 
@@ -44,7 +44,9 @@ class LoggerTests: XCTestCase {
                                                     FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv")!),
             ],
                                                  outputSettings: [
-                                                    OutputSetting(PVLogOutput.self, tagPattern: TagPattern(string: "pv")!),
+                                                    OutputSetting {
+                                                        PVLogOutput(logStore: $0, tagPattern: TagPattern(string: "pv")!)
+                                                    },
             ])
         let logger = try! Logger(configuration: configuration)
         logger.postLog(["page_name": "Top", "user_id": 100], tag: "pv")
@@ -69,9 +71,15 @@ class LoggerTests: XCTestCase {
                                                     FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv.*")!),
             ],
                                                  outputSettings: [
-                                                    OutputSetting(PVLogOutput.self, tagPattern: TagPattern(string: "pv")!),
-                                                    OutputSetting(PVLogOutput.self, tagPattern: TagPattern(string: "pv2")!),
-                                                    OutputSetting(PVLogOutput.self, tagPattern: TagPattern(string: "pv.*")!),
+                                                    OutputSetting {
+                                                        PVLogOutput(logStore: $0, tagPattern: TagPattern(string: "pv")!)
+                                                    },
+                                                    OutputSetting {
+                                                        PVLogOutput(logStore: $0, tagPattern: TagPattern(string: "pv2")!)
+                                                    },
+                                                    OutputSetting {
+                                                        PVLogOutput(logStore: $0, tagPattern: TagPattern(string: "pv.*")!)
+                                                    },
             ])
         let logger = try! Logger(configuration: configuration)
         logger.postLog(["page_name": "Top", "user_id": 100], tag: "pv.top")
@@ -117,9 +125,13 @@ class LoggerTests: XCTestCase {
                                                     FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv.*")!),
             ],
                                                  outputSettings: [
-                                                    OutputSetting(PVLogOutput.self, tagPattern: TagPattern(string: "pv")!),
+                                                    OutputSetting {
+                                                        PVLogOutput(logStore: $0, tagPattern: TagPattern(string: "pv")!)
+                                                    },
                                                     CustomOutputSetting(tableName: "pv_log"),
-                                                    OutputSetting(PVLogOutput.self, tagPattern: TagPattern(string: "pv.*")!),
+                                                    OutputSetting {
+                                                        PVLogOutput(logStore: $0, tagPattern: TagPattern(string: "pv.*")!)
+                                                    },
             ])
         let logger = try! Logger(configuration: configuration)
         logger.postLog(["page_name": "Top", "user_id": 100], tag: "pv.top")
@@ -139,7 +151,9 @@ class LoggerTests: XCTestCase {
                                                     FilterSetting(PVLogFilter.self, tagPattern: TagPattern(string: "pv")!),
                                                     ],
                                                  outputSettings: [
-                                                    OutputSetting(PVLogOutput.self, tagPattern: TagPattern(string: "pv")!),
+                                                    OutputSetting {
+                                                        PVLogOutput(logStore: $0, tagPattern: TagPattern(string: "pv")!)
+                                                    },
                                                     ])
         let logger = try! Logger(configuration: configuration)
 

--- a/Tests/PureeTests/Output/BufferedOutputTests.swift
+++ b/Tests/PureeTests/Output/BufferedOutputTests.swift
@@ -34,7 +34,7 @@ class BufferedOutputTests: XCTestCase {
     let logStore = InMemoryLogStore()
 
     override func setUp() {
-        output = TestingBufferedOutput(logStore: logStore, tagPattern: TagPattern(string: "pv")!, options: nil)
+        output = TestingBufferedOutput(logStore: logStore, tagPattern: TagPattern(string: "pv")!)
         output.configuration.flushInterval = TimeInterval.infinity
         output.start()
     }
@@ -202,7 +202,7 @@ class BufferedOutputAsyncTests: XCTestCase {
     let logStore = InMemoryLogStore()
 
     override func setUp() {
-        output = TestingBufferedOutputAsync(logStore: logStore, tagPattern: TagPattern(string: "pv")!, options: nil)
+        output = TestingBufferedOutputAsync(logStore: logStore, tagPattern: TagPattern(string: "pv")!)
         output.configuration.flushInterval = TimeInterval.infinity
         output.start()
     }
@@ -387,7 +387,7 @@ class BufferedOutputDispatchQueueTests: XCTestCase {
 
         dispatchQueue.async {
             let logStore = InMemoryLogStore()
-            let output = TestingBufferedOutput(logStore: logStore, tagPattern: TagPattern(string: "pv")!, options: nil)
+            let output = TestingBufferedOutput(logStore: logStore, tagPattern: TagPattern(string: "pv")!)
             output.configuration = BufferedOutput.Configuration(logEntryCountLimit: 5, flushInterval: 0, retryLimit: 3)
             output.start()
 


### PR DESCRIPTION
## Motivation

I just want to pass dependencies to Output class which inherits `BufferedOutput`. The interface of initializer can't be changed because it's required by `Output` protocol.
But the initializer is used only in `OutputSetting` and no need to instantiate from common initializer instead of closure.

## What changed

I changed to use closure to instantiate `OutputSetting` and remove `OutputOptions` because no need to use common interface of initializer.
And I added `InstantiatableOutput` for backward compatibility. If you used `OutputSetting.init(O.Type,tagPattern: TagPattern)`, need to conform `InstantiatableOutput`
