### PR TITLE
Support AppExtension

### DIFF
--- a/Puree.xcodeproj/project.pbxproj
+++ b/Puree.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 		BC_386656661306 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -396,6 +397,7 @@
 		BC_591140202817 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
Thank you for awesome library.

# Motivation and Context

We are want to use an AppExtension project. (ex: Share Extension, Today Extension)

# Description
If this option set to YES. Puree-Swift can't use NS_EXTENSION_UNAVAILABLE apis. 
  - UIApplication.shared

