### PR TITLE
BufferedOutput must be InstantiatableOutput

### DIFF
--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-open class BufferedOutput: Output {
+open class BufferedOutput: InstantiatableOutput {
     private let dateProvider: DateProvider = DefaultDateProvider()
     internal let readWriteQueue = DispatchQueue(label: "com.cookpad.Puree.Logger.BufferedOutput", qos: .background)
 
-    public init(logStore: LogStore, tagPattern: TagPattern) {
+    required public init(logStore: LogStore, tagPattern: TagPattern, options: OutputOptions? = nil) {
         self.logStore = logStore
         self.tagPattern = tagPattern
     }

--- a/Tests/PureeTests/LoggerTests.swift
+++ b/Tests/PureeTests/LoggerTests.swift
@@ -57,7 +57,7 @@ class LoggerTests: XCTestCase {
         XCTAssertEqual(buffer.logs(for: "pv").count, 1)
 
         let log = buffer.logs(for: "pv").first!
-        guard let userInfo = try? JSONSerialization.jsonObject(with: log.userData!, options: []) as! [String: Any] else {
+        guard let userInfo = try? (JSONSerialization.jsonObject(with: log.userData!, options: []) as! [String: Any]) else {
             return XCTFail("userInfo could not decoded")
         }
         XCTAssertEqual(userInfo["page_name"] as! String, "Top")
@@ -191,7 +191,7 @@ class LoggerTests: XCTestCase {
 
         for index in testIndices {
             let found = logs.contains { log -> Bool in
-                guard let userInfo = try? JSONSerialization.jsonObject(with: log.userData!, options: []) as! [String: Any] else {
+                guard let userInfo = try? JSONSerialization.jsonObject(with: log.userData!, options: []) as? [String: Any] else {
                     XCTFail("userInfo could not decoded")
                     return false
                 }


### PR DESCRIPTION
I tried #22 to upgrade for Puree-Swift 5.1.

However, this patch brakes backward compatibilities. I made small fixes to upgrade.