### PR TITLE
Change host runner name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Puree
 on: [push, pull_request]
 jobs:
   iOS:
-    runs-on: macos
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Run Tests with Xcode
@@ -10,13 +10,13 @@ jobs:
         DESTINATION="platform=iOS Simulator,name=iPhone 8" SCHEME="Puree"
         xcodebuild test -project Puree.xcodeproj -scheme "${SCHEME}" -destination "${DESTINATION}"
   SwiftPM:
-    runs-on: macos
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Run Tests with Swift Package Manager
       run: swift test -Xswiftc "-target" -Xswiftc "x86_64-apple-macosx10.12"
   Lint:
-    runs-on: macos
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies


### PR DESCRIPTION
Previously, GitHub-hosted runner was configured as `macos`, but now tests fails with `No runner matching the specified labels was found: macos.` error. So I changed label to `macos-latest`.
https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners