### PR TITLE
Throwable LogStore initializer

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/Puree/LogStore/FileLogStore.swift
+++ b/Sources/Puree/LogStore/FileLogStore.swift
@@ -51,9 +51,13 @@ struct SystemFileManager: FileManagerProtocol {
 public class FileLogStore: LogStore {
     private static let directoryName = "PureeLogs"
     private var bundle: Bundle = Bundle.main
-    private var baseDirectoryURL: URL!
+    private var baseDirectoryURL: URL
 
-    public static let `default` = FileLogStore()
+    public required  init() throws {
+        let cacheDirectoryURL = try fileManager.cachesDirectoryURL()
+        baseDirectoryURL = cacheDirectoryURL.appendingPathComponent(FileLogStore.directoryName)
+        try createCachesDirectory()
+    }
 
     private func fileURL(for group: String) -> URL {
         // Tag patterns usually contain '*'. However we don't want to use special characters in filenames
@@ -81,12 +85,6 @@ public class FileLogStore: LogStore {
 
     private func createCachesDirectory() throws {
         try fileManager.createEmptyDirectoryIfNeeded(at: baseDirectoryURL)
-    }
-
-    public func prepare() throws {
-        let cacheDirectoryURL = try fileManager.cachesDirectoryURL()
-        baseDirectoryURL = cacheDirectoryURL.appendingPathComponent(FileLogStore.directoryName)
-        try createCachesDirectory()
     }
 
     public func add(_ logs: Set<LogEntry>, for group: String, completion: (() -> Void)?) {

--- a/Sources/Puree/LogStore/LogStore.swift
+++ b/Sources/Puree/LogStore/LogStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public protocol LogStore {
-    func prepare() throws
+    init() throws
     func retrieveLogs(of group: String, completion: (Set<LogEntry>) -> Void)
     func add(_ log: LogEntry, for group: String, completion: (() -> Void)?)
     func add(_ logs: Set<LogEntry>, for group: String, completion: (() -> Void)?)

--- a/Sources/Puree/Logger.swift
+++ b/Sources/Puree/Logger.swift
@@ -7,11 +7,11 @@ public final class Logger {
         public var filterSettings: [FilterSettingProtocol] = []
         public var outputSettings: [OutputSettingProtocol] = []
 
-        public init(logStore: LogStore.Type,
+        public init(logStoreType: LogStore.Type,
                     dateProvider: DateProvider = DefaultDateProvider(),
                     filterSettings: [FilterSettingProtocol],
                     outputSettings: [OutputSettingProtocol]) {
-            self.logStoreType = logStore
+            self.logStoreType = logStoreType
             self.dateProvider = dateProvider
             self.filterSettings = filterSettings
             self.outputSettings = outputSettings

--- a/Tests/PureeTests/LogStore/FileLogStoreTests.swift
+++ b/Tests/PureeTests/LogStore/FileLogStoreTests.swift
@@ -4,13 +4,12 @@ import Puree
 
 class FileLogStoreTests: XCTestCase {
     var logStore: LogStore {
-        return FileLogStore.default
+        return try! FileLogStore()
     }
 
     override func setUp() {
         super.setUp()
 
-        try! logStore.prepare()
         logStore.flush()
     }
 

--- a/Tests/PureeTests/LoggerTests.swift
+++ b/Tests/PureeTests/LoggerTests.swift
@@ -38,7 +38,7 @@ class LoggerTests: XCTestCase {
     let logStore: InMemoryLogStore = { try! InMemoryLogStore() }()
 
     func testLoggerWithSingleTag() {
-        let configuration = Logger.Configuration(logStore: InMemoryLogStore.self,
+        let configuration = Logger.Configuration(logStoreType: InMemoryLogStore.self,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
                                                     FilterSetting {
@@ -65,7 +65,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testLoggerWithMultipleTag() {
-        let configuration = Logger.Configuration(logStore: InMemoryLogStore.self,
+        let configuration = Logger.Configuration(logStoreType: InMemoryLogStore.self,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
                                                     FilterSetting {
@@ -125,7 +125,7 @@ class LoggerTests: XCTestCase {
             }
         }
 
-        let configuration = Logger.Configuration(logStore: InMemoryLogStore.self,
+        let configuration = Logger.Configuration(logStoreType: InMemoryLogStore.self,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
                                                     FilterSetting {
@@ -157,7 +157,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testLoggerWithMultiThread() {
-        let configuration = Logger.Configuration(logStore: InMemoryLogStore.self,
+        let configuration = Logger.Configuration(logStoreType: InMemoryLogStore.self,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
                                                     FilterSetting {

--- a/Tests/PureeTests/LoggerTests.swift
+++ b/Tests/PureeTests/LoggerTests.swift
@@ -35,10 +35,10 @@ struct PVLogOutput: Output {
 }
 
 class LoggerTests: XCTestCase {
-    let logStore = InMemoryLogStore()
+    let logStore: InMemoryLogStore = { try! InMemoryLogStore() }()
 
     func testLoggerWithSingleTag() {
-        let configuration = Logger.Configuration(logStore: logStore,
+        let configuration = Logger.Configuration(logStore: InMemoryLogStore.self,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
                                                     FilterSetting {
@@ -65,7 +65,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testLoggerWithMultipleTag() {
-        let configuration = Logger.Configuration(logStore: logStore,
+        let configuration = Logger.Configuration(logStore: InMemoryLogStore.self,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
                                                     FilterSetting {
@@ -125,7 +125,7 @@ class LoggerTests: XCTestCase {
             }
         }
 
-        let configuration = Logger.Configuration(logStore: logStore,
+        let configuration = Logger.Configuration(logStore: InMemoryLogStore.self,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
                                                     FilterSetting {
@@ -157,7 +157,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testLoggerWithMultiThread() {
-        let configuration = Logger.Configuration(logStore: logStore,
+        let configuration = Logger.Configuration(logStore: InMemoryLogStore.self,
                                                  dateProvider: DefaultDateProvider(),
                                                  filterSettings: [
                                                     FilterSetting {

--- a/Tests/PureeTests/Output/BufferedOutputTests.swift
+++ b/Tests/PureeTests/Output/BufferedOutputTests.swift
@@ -31,7 +31,7 @@ class TestingBufferedOutput: BufferedOutput {
 
 class BufferedOutputTests: XCTestCase {
     var output: TestingBufferedOutput!
-    let logStore = InMemoryLogStore()
+    let logStore = { try! InMemoryLogStore() }()
 
     override func setUp() {
         output = TestingBufferedOutput(logStore: logStore, tagPattern: TagPattern(string: "pv")!)
@@ -199,7 +199,7 @@ class TestingBufferedOutputAsync: TestingBufferedOutput {
 
 class BufferedOutputAsyncTests: XCTestCase {
     var output: TestingBufferedOutputAsync!
-    let logStore = InMemoryLogStore()
+    let logStore = { try! InMemoryLogStore() }()
 
     override func setUp() {
         output = TestingBufferedOutputAsync(logStore: logStore, tagPattern: TagPattern(string: "pv")!)
@@ -381,12 +381,12 @@ class BufferedOutputAsyncTests: XCTestCase {
 
 class BufferedOutputDispatchQueueTests: XCTestCase {
 
-    func testFlushIntervalOnDifferentDispatchQueue() {
+    func testFlushIntervalOnDifferentDispatchQueue() throws {
         let exp = expectation(description: #function)
         let dispatchQueue = DispatchQueue(label: "com.cookpad.Puree.Logger", qos: .background)
+        let logStore = try XCTUnwrap(InMemoryLogStore())
 
         dispatchQueue.async {
-            let logStore = InMemoryLogStore()
             let output = TestingBufferedOutput(logStore: logStore, tagPattern: TagPattern(string: "pv")!)
             output.configuration = BufferedOutput.Configuration(logEntryCountLimit: 5, flushInterval: 0, retryLimit: 3)
             output.start()

--- a/Tests/PureeTests/Utilities/InMemoryLogStore.swift
+++ b/Tests/PureeTests/Utilities/InMemoryLogStore.swift
@@ -4,7 +4,7 @@ import Puree
 class InMemoryLogStore: LogStore {
     private var buffer: [String: Set<LogEntry>] = [:]
 
-    func prepare() throws {
+    required init() throws {
     }
 
     func logs(for group: String) -> Set<LogEntry> {


### PR DESCRIPTION
## Motivation and Context

Currently, `FileLogStore` has an IUO property. In the real world apps, it sometimes causes crashes.

So I modified the initialization interface of `LogStore` to avoid IUO properties.

## Description

I use a throwable initializer instead of `prepare` method.

## Compatibility

This PR doesn't impact users who uses default LogStores. Most users may use default LogStore.
Users who own their custom LogStores have to change their implements to adapt to the new interface.
