### PR TITLE
Avoid IUO on FileLogStore

### DIFF
--- a/Sources/Puree/LogStore/FileLogStore.swift
+++ b/Sources/Puree/LogStore/FileLogStore.swift
@@ -54,7 +54,7 @@ public class FileLogStore: LogStore {
     private var baseDirectoryURL: URL?
 
     public enum Error: Swift.Error {
-        case unknownBaseDirectoryUnavailable
+        case baseDirectoryUnavailable
     }
 
     public static let `default` = FileLogStore()
@@ -84,7 +84,7 @@ public class FileLogStore: LogStore {
     }
 
     private func createCachesDirectory() throws {
-        guard let baseDirectoryURL = self.baseDirectoryURL else { throw Error.unknownBaseDirectoryUnavailable }
+        guard let baseDirectoryURL = self.baseDirectoryURL else { throw Error.baseDirectoryUnavailable }
         try fileManager.createEmptyDirectoryIfNeeded(at: baseDirectoryURL)
     }
 

--- a/Sources/Puree/LogStore/FileLogStore.swift
+++ b/Sources/Puree/LogStore/FileLogStore.swift
@@ -54,7 +54,7 @@ public class FileLogStore: LogStore {
     private var baseDirectoryURL: URL?
 
     public enum Error: Swift.Error {
-        case unknownBaseDirectory
+        case unknownBaseDirectoryUnavailable
     }
 
     public static let `default` = FileLogStore()
@@ -84,7 +84,7 @@ public class FileLogStore: LogStore {
     }
 
     private func createCachesDirectory() throws {
-        guard let baseDirectoryURL = self.baseDirectoryURL else { throw Error.unknownBaseDirectory }
+        guard let baseDirectoryURL = self.baseDirectoryURL else { throw Error.unknownBaseDirectoryUnavailable }
         try fileManager.createEmptyDirectoryIfNeeded(at: baseDirectoryURL)
     }
 

--- a/Sources/Puree/LogStore/FileLogStore.swift
+++ b/Sources/Puree/LogStore/FileLogStore.swift
@@ -51,19 +51,23 @@ struct SystemFileManager: FileManagerProtocol {
 public class FileLogStore: LogStore {
     private static let directoryName = "PureeLogs"
     private var bundle: Bundle = Bundle.main
-    private var baseDirectoryURL: URL!
+    private var baseDirectoryURL: URL?
+
+    public enum Error: Swift.Error {
+        case unknownBaseDirectory
+    }
 
     public static let `default` = FileLogStore()
 
-    private func fileURL(for group: String) -> URL {
+    private func fileURL(for group: String) -> URL? {
         // Tag patterns usually contain '*'. However we don't want to use special characters in filenames
         // so encode file names to Base16
-        return baseDirectoryURL.appendingPathComponent(encodeToBase16(group))
+        return baseDirectoryURL?.appendingPathComponent(encodeToBase16(group))
     }
     private var fileManager: FileManagerProtocol = SystemFileManager()
 
     private func storedLogs(of group: String) -> Set<LogEntry> {
-        if let data = fileManager.load(from: fileURL(for: group)) {
+        if let fileURL = fileURL(for: group), let data = fileManager.load(from: fileURL) {
             let decorder = PropertyListDecoder()
             if let logs = try? decorder.decode([LogEntry].self, from: data) {
                 return Set<LogEntry>(logs)
@@ -74,12 +78,13 @@ public class FileLogStore: LogStore {
 
     private func write(_ logs: Set<LogEntry>, for group: String) {
         let encoder = PropertyListEncoder()
-        if let data = try? encoder.encode(logs) {
-            try? fileManager.write(data, to: fileURL(for: group))
+        if let fileURL = fileURL(for: group), let data = try? encoder.encode(logs) {
+            try? fileManager.write(data, to: fileURL)
         }
     }
 
     private func createCachesDirectory() throws {
+        guard let baseDirectoryURL = self.baseDirectoryURL else { throw Error.unknownBaseDirectory }
         try fileManager.createEmptyDirectoryIfNeeded(at: baseDirectoryURL)
     }
 
@@ -107,7 +112,9 @@ public class FileLogStore: LogStore {
     }
 
     public func flush() {
-        try? fileManager.removeDirectory(at: baseDirectoryURL)
+        if let baseDirectoryURL = baseDirectoryURL {
+            try? fileManager.removeDirectory(at: baseDirectoryURL)
+        }
         try? createCachesDirectory()
     }
 


### PR DESCRIPTION
This PR is another proposal of #31's issue.

This PR made IUO properties to optional. This helps to avoid unknown crashes without any interface changes.