### PR TITLE
Unify Minimum Support iOS Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Puree",
     platforms: [
-        .iOS(.v12),
+        .iOS(.v10),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Puree.podspec
+++ b/Puree.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Puree"
-  s.version      = "5.1.2"
+  s.version      = "5.1.3"
   s.summary      = "Awesome log aggregator"
   s.homepage     = "https://github.com/cookpad/Puree-Swift"
   s.license      = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
Minimum support iOS version for Swift Package Manager is higher than for cocoapods, so unified the version.