### PR TITLE
Add data size limit to BufferedOutput

### DIFF
--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -160,8 +160,14 @@ open class BufferedOutput: InstantiatableOutput {
         let newBuffer = Set(buffer.dropFirst(logCount))
         let dropped = buffer.subtracting(newBuffer)
         buffer = newBuffer
-        let chunk = Chunk(logs: dropped)
-        callWriteChunk(chunk)
+        prepareChunk(logs: dropped)
+            .forEach { (chunk) in
+                callWriteChunk(chunk)
+            }
+    }
+
+    open func prepareChunk(logs: Set<LogEntry>) -> [Chunk] {
+        [ Chunk(logs: logs) ]
     }
 
     open func delay(try count: Int) -> TimeInterval {

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -96,6 +96,17 @@ open class BufferedOutput: InstantiatableOutput {
 
             if buffer.count >= logLimit {
                 flush()
+            } else if let logSizeLimit = configuration.logDataSizeLimit {
+                let currentBufferedLogSize = buffer.reduce(0, { (size, log) -> Int in
+                    size + (log.userData?.count ?? 0)
+                })
+
+                print("[hoge] count: \(buffer.count)")
+                print("[hoge] count: \(currentBufferedLogSize)")
+
+                if currentBufferedLogSize >= logSizeLimit {
+                    flush()
+                }
             }
         }
     }
@@ -175,6 +186,7 @@ open class BufferedOutput: InstantiatableOutput {
                     logsUnderSizeLimit.insert(log)
                     currentTotalLogSize += log.userData?.count ?? 0
                 } else {
+                    buffer = dropped.subtracting(logsUnderSizeLimit)
                     break
                 }
             }

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -91,6 +91,11 @@ open class BufferedOutput: InstantiatableOutput {
 
     public func emit(log: LogEntry) {
         readWriteQueue.sync {
+            if let logSizeLimit = configuration.chunkDataSizeLimit, (log.userData?.count ?? 0) > logSizeLimit {
+                // Data whose size is larger than limit will never be sent.
+                return
+            }
+
             buffer.insert(log)
             logStore.add(log, for: storageGroup, completion: nil)
 

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -13,7 +13,7 @@ open class BufferedOutput: InstantiatableOutput {
         public let logs: Set<LogEntry>
         private(set) var retryCount: Int = 0
 
-        public init(logs: Set<LogEntry>) {
+        fileprivate init(logs: Set<LogEntry>) {
             self.logs = logs
         }
 

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -167,7 +167,7 @@ open class BufferedOutput: InstantiatableOutput {
     }
 
     open func prepareChunk(logs: Set<LogEntry>) -> [Chunk] {
-        [ Chunk(logs: logs) ]
+        return [ Chunk(logs: logs) ]
     }
 
     open func delay(try count: Int) -> TimeInterval {

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -101,9 +101,6 @@ open class BufferedOutput: InstantiatableOutput {
                     size + (log.userData?.count ?? 0)
                 })
 
-                print("[hoge] count: \(buffer.count)")
-                print("[hoge] count: \(currentBufferedLogSize)")
-
                 if currentBufferedLogSize >= logSizeLimit {
                     flush()
                 }

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -33,9 +33,9 @@ open class BufferedOutput: InstantiatableOutput {
         public var logEntryCountLimit: Int
         public var flushInterval: TimeInterval
         public var retryLimit: Int
-        public var logDataSizeLimit: Int?
+        public var chunkDataSizeLimit: Int?
 
-        public static let `default` = Configuration(logEntryCountLimit: 5, flushInterval: 10, retryLimit: 3, logDataSizeLimit: nil)
+        public static let `default` = Configuration(logEntryCountLimit: 5, flushInterval: 10, retryLimit: 3, chunkDataSizeLimit: nil)
     }
 
     public let tagPattern: TagPattern
@@ -58,7 +58,7 @@ open class BufferedOutput: InstantiatableOutput {
     }
 
     private var sizeLimit: Int? {
-        return configuration.logDataSizeLimit
+        return configuration.chunkDataSizeLimit
     }
 
     private var currentDate: Date {
@@ -96,7 +96,7 @@ open class BufferedOutput: InstantiatableOutput {
 
             if buffer.count >= logLimit {
                 flush()
-            } else if let logSizeLimit = configuration.logDataSizeLimit {
+            } else if let logSizeLimit = configuration.chunkDataSizeLimit {
                 let currentBufferedLogSize = buffer.reduce(0, { (size, log) -> Int in
                     size + (log.userData?.count ?? 0)
                 })
@@ -177,12 +177,12 @@ open class BufferedOutput: InstantiatableOutput {
         let dropped = buffer.subtracting(newBuffer)
         buffer = newBuffer
         let logsToSend: Set<LogEntry>
-        if let logDataSizeLimit = configuration.logDataSizeLimit {
+        if let chunkDataSizeLimit = configuration.chunkDataSizeLimit {
             var logsUnderSizeLimit = Set<LogEntry>()
 
             var currentTotalLogSize = 0
             for log in dropped {
-                if currentTotalLogSize + (log.userData?.count ?? 0) < logDataSizeLimit {
+                if currentTotalLogSize + (log.userData?.count ?? 0) < chunkDataSizeLimit {
                     logsUnderSizeLimit.insert(log)
                     currentTotalLogSize += log.userData?.count ?? 0
                 } else {

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -13,7 +13,7 @@ open class BufferedOutput: InstantiatableOutput {
         public let logs: Set<LogEntry>
         private(set) var retryCount: Int = 0
 
-        fileprivate init(logs: Set<LogEntry>) {
+        public init(logs: Set<LogEntry>) {
             self.logs = logs
         }
 

--- a/Tests/PureeTests/Output/BufferedOutputTests.swift
+++ b/Tests/PureeTests/Output/BufferedOutputTests.swift
@@ -144,6 +144,21 @@ class BufferedOutputTests: XCTestCase {
         XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 2)
     }
 
+    func testEmittingOneLogLargerThanSizeLimit() {
+        // Set maximum chunk size as 5bytes
+        output.configuration.chunkDataSizeLimit = 5
+
+        // Disable to send according to log count
+        output.configuration.logEntryCountLimit = .max
+
+        // A log entry that has data larger than limit will be discarded.
+        var log1 = makeLog()
+        log1.userData = "0123456789".data(using: .utf8)
+        output.emit(log: log1)
+        XCTAssertEqual(output.calledWriteCount, 0)
+        XCTAssertEqual(logStore.logs(for: "pv_TestingBufferedOutput").count, 0)
+    }
+
     func testRetryWhenFailed() {
         output.shouldSuccess = false
         output.configuration.logEntryCountLimit = 10


### PR DESCRIPTION
- add `chunkDataSizeLimit` to `BufferedOutput.Configuration`
- send logs before total data size in buffer reached its size limit even if buffered log count is less than count limit
- add a test case