### PR TITLE
Add public memberwise initializer

### DIFF
--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -36,6 +36,13 @@ open class BufferedOutput: InstantiatableOutput {
         public var chunkDataSizeLimit: Int?
 
         public static let `default` = Configuration(logEntryCountLimit: 5, flushInterval: 10, retryLimit: 3, chunkDataSizeLimit: nil)
+
+        public init(logEntryCountLimit: Int, flushInterval: TimeInterval, retryLimit: Int, chunkDataSizeLimit: Int? = nil) {
+            self.logEntryCountLimit = logEntryCountLimit
+            self.flushInterval = flushInterval
+            self.retryLimit = retryLimit
+            self.chunkDataSizeLimit = chunkDataSizeLimit
+        }
     }
 
     public let tagPattern: TagPattern

--- a/Sources/Puree/Output/BufferedOutput.swift
+++ b/Sources/Puree/Output/BufferedOutput.swift
@@ -98,7 +98,7 @@ open class BufferedOutput: InstantiatableOutput {
 
     public func emit(log: LogEntry) {
         readWriteQueue.sync {
-            if let logSizeLimit = configuration.chunkDataSizeLimit, (log.userData?.count ?? 0) > logSizeLimit {
+            if let logSizeLimit = sizeLimit, (log.userData?.count ?? 0) > logSizeLimit {
                 // Data whose size is larger than limit will never be sent.
                 return
             }
@@ -108,7 +108,7 @@ open class BufferedOutput: InstantiatableOutput {
 
             if buffer.count >= logLimit {
                 flush()
-            } else if let logSizeLimit = configuration.chunkDataSizeLimit {
+            } else if let logSizeLimit = sizeLimit {
                 let currentBufferedLogSize = buffer.reduce(0, { (size, log) -> Int in
                     size + (log.userData?.count ?? 0)
                 })
@@ -186,7 +186,7 @@ open class BufferedOutput: InstantiatableOutput {
         let dropped = buffer.subtracting(newBuffer)
         buffer = newBuffer
         let logsToSend: Set<LogEntry>
-        if let chunkDataSizeLimit = configuration.chunkDataSizeLimit {
+        if let chunkDataSizeLimit = sizeLimit {
             var logsUnderSizeLimit = Set<LogEntry>()
 
             var currentTotalLogSize = 0


### PR DESCRIPTION
## Motivation
I wanted to specify a custom configuration for`BufferdOutput`, but when I initialize the configuration, I got the following error.
`initializer is inaccessible due to 'internal' protection level`.

## What changed
- I've added a public memberwise initializer according to the following document. 7ab39af

https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html
> As with the default initializer above, if you want a public structure type to be initializable with a memberwise initializer when used in another module, You must provide a public memberwise initializer yourself as part of the type's definition.

- Changed to use the sizeLimit private property like any other properties. ae8aa95