### PR TITLE
Introduce BufferedOutput.sendBufferedLog

### DIFF
--- a/Sources/Puree/Logger.swift
+++ b/Sources/Puree/Logger.swift
@@ -79,6 +79,12 @@ public final class Logger {
         }
     }
 
+    public func sendBufferedLogs() {
+        dispatchQueue.sync {
+            outputs.forEach { ($0 as? BufferedOutput)?.sendBufferedLogs() }
+        }
+    }
+
     public func suspend() {
         dispatchQueue.sync {
             outputs.forEach { $0.suspend() }

--- a/Tests/PureeTests/Output/BufferedOutputTests.swift
+++ b/Tests/PureeTests/Output/BufferedOutputTests.swift
@@ -101,7 +101,7 @@ class BufferedOutputTests: XCTestCase {
         XCTAssertEqual(output.calledWriteCount, 0)
 
         output.writeCallback = {
-            XCTFail("flush should not be called")
+            XCTFail("writeBufferedLogs should not be called")
         }
         sleep(2)
     }
@@ -351,7 +351,7 @@ class BufferedOutputAsyncTests: XCTestCase {
         XCTAssertEqual(output.calledWriteCount, 0)
 
         output.writeCallback = {
-            XCTFail("flush should not be called")
+            XCTFail("writeBufferedLogs should not be called")
         }
         sleep(2)
     }


### PR DESCRIPTION
Added `sendBufferedLog` method in `BufferedOutput` to be able to send buffered logs manually.
