### PR TITLE
Bump version to 5.3.0

### DIFF
--- a/Puree.podspec
+++ b/Puree.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Puree"
-  s.version      = "5.2.0"
+  s.version      = "5.3.0"
   s.summary      = "Awesome log aggregator"
   s.homepage     = "https://github.com/cookpad/Puree-Swift"
   s.license      = { :type => "MIT", :file => "LICENSE" }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The [Swift Package Manager](https://swift.org/package-manager/) is a tool for au
 Once you have your Swift package set up, adding Puree-Swift as a dependency is as easy as adding it to the `dependencies` value of your `Package.swift`.
 ```swift
 dependencies: [
-    .package(url: "https://github.com/cookpad/Puree-Swift.git", .upToNextMinor(from: "5.2.0"))
+    .package(url: "https://github.com/cookpad/Puree-Swift.git", .upToNextMinor(from: "5.3.0"))
 ]
 ```
 


### PR DESCRIPTION
We would like to release https://github.com/cookpad/Puree-Swift/pull/39 in 5.3.0.